### PR TITLE
spotify client 구현 [access-token]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ UMPA의 서비스들을 통합적으로 관리하는 mono repository
 
 ```Node.js + mongoDB```로 구축한 서버를 ```Kotlin + Spring + RDS``` 기반으로 마이그레이션을 진행합니다.
 
+기존에는 음원 정보를 [Apple Music API](https://developer.apple.com/documentation/applemusicapi)를 이용했지만
+무료로 이용하기 위해 [Spotify API](https://developer.spotify.com/)를 이용합니다.
+
 ***
 
 ## Model

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,13 @@ allprojects {
     }
 }
 
+dependencyManagement {
+    val springCloudVersion: String by project
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion")
+    }
+}
+
 subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jetbrains.kotlin.kapt")

--- a/clients/spotify/build.gradle.kts
+++ b/clients/spotify/build.gradle.kts
@@ -1,0 +1,5 @@
+val openFeignVersion: String by project
+
+dependencies {
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign:$openFeignVersion")
+}

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyApi.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyApi.kt
@@ -1,12 +1,17 @@
 package com.umpa.client.spotify
 
 import com.umpa.client.spotify.auth.BasicAuth
+import com.umpa.client.spotify.auth.BearerAuth
+import com.umpa.client.spotify.enums.FilterType
 import com.umpa.client.spotify.response.AccessTokenResponse
+import com.umpa.client.spotify.response.SearchResponse
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
+import java.net.URI
 
 @FeignClient(
     name = "spotify-api",
@@ -20,7 +25,21 @@ interface SpotifyApi {
         produces = [MediaType.APPLICATION_JSON_VALUE]
     )
     fun getAccessToken(
+        uri: URI,
         @RequestHeader("Authorization") auth: BasicAuth,
         @RequestParam("grant_type") grantType: String = "client_credentials"
     ): AccessTokenResponse
+
+    @GetMapping(
+        value = ["/v1/search"],
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun search(
+        @RequestHeader("Authorization") auth: BearerAuth,
+        @RequestParam("q") keyword: String,
+        @RequestParam type: String = FilterType.TRACK.name.lowercase(),
+        @RequestParam limit: Int? = 20,
+        @RequestParam offset: Int? = 0
+    ): SearchResponse
 }

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyApi.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyApi.kt
@@ -1,0 +1,26 @@
+package com.umpa.client.spotify
+
+import com.umpa.client.spotify.auth.BasicAuth
+import com.umpa.client.spotify.response.AccessTokenResponse
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+
+@FeignClient(
+    name = "spotify-api",
+    url = "\${spotify.api.url}"
+)
+interface SpotifyApi {
+
+    @PostMapping(
+        value = ["/api/token"],
+        consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun getAccessToken(
+        @RequestHeader("Authorization") auth: BasicAuth,
+        @RequestParam("grant_type") grantType: String = "client_credentials"
+    ): AccessTokenResponse
+}

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyClient.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyClient.kt
@@ -1,12 +1,17 @@
 package com.umpa.client.spotify
 
 import com.umpa.client.spotify.auth.basicAuth
+import com.umpa.client.spotify.auth.bearerAuth
+import com.umpa.client.spotify.response.TrackResponse
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import java.net.URI
 
 @Component
 class SpotifyClient(
     private val spotifyApi: SpotifyApi,
+    @Value("\${spotify.api.authorization.url}")
+    private val authorizationBaseUrl: String,
     @Value("\${spotify.api.client.key}")
     private val clientKey: String,
     @Value("\${spotify.api.secret.key}")
@@ -14,9 +19,20 @@ class SpotifyClient(
 ) {
     fun getAccessToken(): String {
         val token = spotifyApi.getAccessToken(
+            uri = URI(authorizationBaseUrl),
             auth = basicAuth(clientKey, secretKey)
         ).token
         // TODO token caching
         return token
+    }
+
+    fun search(keyword: String, limit: Int?, offset: Int?): TrackResponse {
+        val token = getAccessToken()
+        return spotifyApi.search(
+            auth = bearerAuth(token),
+            keyword = keyword,
+            limit = limit,
+            offset = offset
+        ).tracks
     }
 }

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyClient.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyClient.kt
@@ -1,0 +1,22 @@
+package com.umpa.client.spotify
+
+import com.umpa.client.spotify.auth.basicAuth
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class SpotifyClient(
+    private val spotifyApi: SpotifyApi,
+    @Value("\${spotify.api.client.key}")
+    private val clientKey: String,
+    @Value("\${spotify.api.secret.key}")
+    private val secretKey: String
+) {
+    fun getAccessToken(): String {
+        val token = spotifyApi.getAccessToken(
+            auth = basicAuth(clientKey, secretKey)
+        ).token
+        // TODO token caching
+        return token
+    }
+}

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyConfig.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyConfig.kt
@@ -1,0 +1,15 @@
+package com.umpa.client.spotify
+
+import feign.Logger
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableFeignClients
+internal class SpotifyConfig {
+    @Bean
+    internal fun feignLoggerLevel(): Logger.Level {
+        return Logger.Level.FULL
+    }
+}

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/auth/AuthExtension.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/auth/AuthExtension.kt
@@ -1,0 +1,9 @@
+package com.umpa.client.spotify.auth
+
+import java.util.Base64
+
+typealias BasicAuth = String
+
+fun basicAuth(client: String, secret: String): String = "Basic ${Base64.getEncoder().encodeToString(
+    "$client:$secret".toByteArray()
+)}"

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/auth/AuthExtension.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/auth/AuthExtension.kt
@@ -4,6 +4,10 @@ import java.util.Base64
 
 typealias BasicAuth = String
 
+typealias BearerAuth = String
+
 fun basicAuth(client: String, secret: String): String = "Basic ${Base64.getEncoder().encodeToString(
     "$client:$secret".toByteArray()
 )}"
+
+fun bearerAuth(token: String): String = "Bearer $token"

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/enums/FilterType.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/enums/FilterType.kt
@@ -1,0 +1,5 @@
+package com.umpa.client.spotify.enums
+
+enum class FilterType {
+    ALBUM, ARTIST, PLAYLIST, TRACK, SHOW, EPISODE, AUDIOBOOK
+}

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/AccessTokenResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/AccessTokenResponse.kt
@@ -1,0 +1,12 @@
+package com.umpa.client.spotify.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AccessTokenResponse(
+    @field:JsonProperty("access_token")
+    val token: String,
+    @field:JsonProperty("token_type")
+    val type: String,
+    @field:JsonProperty("expires_in")
+    val expires: Int
+)

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/AlbumResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/AlbumResponse.kt
@@ -1,0 +1,49 @@
+package com.umpa.client.spotify.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AlbumResponse(
+    @field:JsonProperty("album_type")
+    val albumType: String,
+    @field:JsonProperty("total_tracks")
+    val totalTracks: Int,
+    @field:JsonProperty("available_markets")
+    val availableMarkets: List<String>,
+    @field:JsonProperty("external_urls")
+    val externalUrls: ExternalUrlResponse,
+    val href: String,
+    val id: String,
+    val images: List<ImageResponse>,
+    val name: String,
+    @field:JsonProperty("release_date")
+    val releaseDate: String,
+    @field:JsonProperty("release_date_precision")
+    val releaseDatePrecision: String,
+    val restrictions: RestrictionResponse?,
+    val type: String,
+    val uri: String,
+    val copyrights: List<CopyRightResponse>?,
+    @field:JsonProperty("external_ids")
+    val externalIds: List<ExternalIdResponse>?,
+    val genres: List<String>?,
+    val label: String?,
+    val popularity: Int?,
+    @field:JsonProperty("album_group")
+    val albumGroup: String?,
+    val artists: List<ArtistResponse>
+) {
+    data class CopyRightResponse(
+        val text: String?,
+        val type: String?
+    )
+
+    data class ArtistResponse(
+        @field:JsonProperty("external_urls")
+        val externalUrls: ExternalUrlResponse?,
+        val href: String?,
+        val id: String?,
+        val name: String?,
+        val type: String?,
+        val uri: String?
+    )
+}

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ArtistResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ArtistResponse.kt
@@ -1,0 +1,22 @@
+package com.umpa.client.spotify.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class ArtistResponse(
+    @field:JsonProperty("external_urls")
+    val externalUrls: ExternalUrlResponse?,
+    val followers: FollowersResponse?,
+    val genres: List<String>?,
+    val href: String?,
+    val id: String?,
+    val images: List<ImageResponse>?,
+    val name: String?,
+    val popularity: Int?,
+    val type: String?,
+    val uri: String?
+) {
+    data class FollowersResponse(
+        val href: String?,
+        val total: Int?
+    )
+}

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ExternalIdResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ExternalIdResponse.kt
@@ -1,0 +1,7 @@
+package com.umpa.client.spotify.response
+
+data class ExternalIdResponse(
+    val isrc: String?,
+    val ean: String?,
+    val upc: String?
+)

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ExternalUrlResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ExternalUrlResponse.kt
@@ -1,0 +1,5 @@
+package com.umpa.client.spotify.response
+
+data class ExternalUrlResponse(
+    val spotify: String
+)

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ImageResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ImageResponse.kt
@@ -1,0 +1,7 @@
+package com.umpa.client.spotify.response
+
+data class ImageResponse(
+    val url: String,
+    val height: Int?,
+    val width: Int?
+)

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/RestrictionResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/RestrictionResponse.kt
@@ -1,0 +1,5 @@
+package com.umpa.client.spotify.response
+
+data class RestrictionResponse(
+    val reason: String?
+)

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/SearchResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/SearchResponse.kt
@@ -1,0 +1,5 @@
+package com.umpa.client.spotify.response
+
+data class SearchResponse(
+    val tracks: TrackResponse
+)

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/TrackDetailResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/TrackDetailResponse.kt
@@ -1,0 +1,34 @@
+package com.umpa.client.spotify.response
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class TrackDetailResponse(
+    val album: AlbumResponse?,
+    val artists: List<ArtistResponse>?,
+    @field:JsonProperty("available_markets")
+    val availableMarkets: List<String>?,
+    @field:JsonProperty("disc_number")
+    val discNumber: Int?,
+    @field:JsonProperty("duration_ms")
+    val durationMs: Int?,
+    val explicit: Boolean?,
+    @field:JsonProperty("external_ids")
+    val externalIds: ExternalIdResponse?,
+    @field:JsonProperty("external_urls")
+    val externalUrls: ExternalUrlResponse?,
+    val href: String?,
+    val id: String?,
+    @field:JsonProperty("is_playable")
+    val isPlayable: Boolean?,
+    val restrictions: RestrictionResponse?,
+    val name: String?,
+    val popularity: Int?,
+    @field:JsonProperty("preview_url")
+    val previewUrl: String?,
+    @field:JsonProperty("track_number")
+    val trackNumber: Int?,
+    val type: String?,
+    val uri: String?,
+    @field:JsonProperty("is_local")
+    val isLocal: Boolean?
+)

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/TrackResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/TrackResponse.kt
@@ -1,0 +1,11 @@
+package com.umpa.client.spotify.response
+
+data class TrackResponse(
+    val href: String,
+    val limit: Int,
+    val next: String?,
+    val offset: Int,
+    val previous: String?,
+    val total: Int,
+    val items: List<TrackDetailResponse>
+)

--- a/clients/spotify/src/main/resources/spotify.yml
+++ b/clients/spotify/src/main/resources/spotify.yml
@@ -1,0 +1,17 @@
+spotify:
+    api:
+        # access-token 발급을 위한 base url. 기본 base_url과 달라서 동적으로 받을 수 있게끔 구현해야 함
+        url: https://accounts.spotify.com
+        client.key: test-client-key
+        secret.key: test-secret-key
+
+feign:
+    client:
+        config:
+            default:
+                connectTimeout: 3000
+                readTimeout: 2000
+
+logging:
+    level:
+        com.umpa.client.spotify: DEBUG

--- a/clients/spotify/src/main/resources/spotify.yml
+++ b/clients/spotify/src/main/resources/spotify.yml
@@ -1,7 +1,9 @@
 spotify:
     api:
-        # access-token 발급을 위한 base url. 기본 base_url과 달라서 동적으로 받을 수 있게끔 구현해야 함
-        url: https://accounts.spotify.com
+        # access-token 발급을 위한 base url
+        authorization.url: https://accounts.spotify.com
+        # 기본 base url
+        url: https://api.spotify.com
         client.key: test-client-key
         secret.key: test-secret-key
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,10 @@
 kotlinVersion=1.8.21
-springBootVersion=3.1.0
+springBootVersion=3.0.7
 springDependencyManagementVersion=1.1.0
 ktlintVersion=11.3.2
 
 mockkVersion=1.13.5
+
+# spring cloud version
+springCloudVersion=2022.0.3
+openFeignVersion=4.0.1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ rootProject.name = "umpa"
 
 include(
     "commons:api",
+    "clients:spotify",
     "umpa-core-api",
     "storage:db-core"
 )

--- a/umpa-core-api/build.gradle.kts
+++ b/umpa-core-api/build.gradle.kts
@@ -3,6 +3,8 @@ val mockkVersion: String by project
 dependencies {
     implementation(project(":commons:api"))
 
+    implementation(project(":clients:spotify"))
+
     implementation(project(":storage:db-core"))
 
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")

--- a/umpa-core-api/src/main/resources/application.yml
+++ b/umpa-core-api/src/main/resources/application.yml
@@ -4,3 +4,4 @@ spring:
     config:
         import:
             - db.yml
+            - spotify.yml


### PR DESCRIPTION
# Pull Request

## Description
Spotify Client 구현을 위한 뼈대를 제작했습니다. 
- OAuth2를 이용해 access-token을 가져오는 작업을 진행
- search api를 추가하는 작업을 진행

## Type of Change
Please select the relevant option by replacing [ ] with [x].

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Other (please describe)

## Additional Notes
access-token을 매번 가져올 필요 없이 캐싱하는 작업이 필요합니다.