### PR TITLE
곡 검색 추가

### DIFF
--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyApi.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/SpotifyApi.kt
@@ -4,7 +4,7 @@ import com.umpa.client.spotify.auth.BasicAuth
 import com.umpa.client.spotify.auth.BearerAuth
 import com.umpa.client.spotify.enums.FilterType
 import com.umpa.client.spotify.response.AccessTokenResponse
-import com.umpa.client.spotify.response.SearchResponse
+import com.umpa.client.spotify.response.SpotifySearchResponse
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.GetMapping
@@ -41,5 +41,5 @@ interface SpotifyApi {
         @RequestParam type: String = FilterType.TRACK.name.lowercase(),
         @RequestParam limit: Int? = 20,
         @RequestParam offset: Int? = 0
-    ): SearchResponse
+    ): SpotifySearchResponse
 }

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ArtistResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/ArtistResponse.kt
@@ -10,7 +10,7 @@ data class ArtistResponse(
     val href: String?,
     val id: String?,
     val images: List<ImageResponse>?,
-    val name: String?,
+    val name: String,
     val popularity: Int?,
     val type: String?,
     val uri: String?

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/SpotifySearchResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/SpotifySearchResponse.kt
@@ -1,5 +1,5 @@
 package com.umpa.client.spotify.response
 
-data class SearchResponse(
+data class SpotifySearchResponse(
     val tracks: TrackResponse
 )

--- a/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/TrackDetailResponse.kt
+++ b/clients/spotify/src/main/kotlin/com/umpa/client/spotify/response/TrackDetailResponse.kt
@@ -3,25 +3,25 @@ package com.umpa.client.spotify.response
 import com.fasterxml.jackson.annotation.JsonProperty
 
 data class TrackDetailResponse(
-    val album: AlbumResponse?,
-    val artists: List<ArtistResponse>?,
+    val album: AlbumResponse,
+    val artists: List<ArtistResponse>,
     @field:JsonProperty("available_markets")
     val availableMarkets: List<String>?,
     @field:JsonProperty("disc_number")
     val discNumber: Int?,
     @field:JsonProperty("duration_ms")
     val durationMs: Int?,
-    val explicit: Boolean?,
+    val explicit: Boolean,
     @field:JsonProperty("external_ids")
     val externalIds: ExternalIdResponse?,
     @field:JsonProperty("external_urls")
     val externalUrls: ExternalUrlResponse?,
     val href: String?,
-    val id: String?,
+    val id: String,
     @field:JsonProperty("is_playable")
     val isPlayable: Boolean?,
     val restrictions: RestrictionResponse?,
-    val name: String?,
+    val name: String,
     val popularity: Int?,
     @field:JsonProperty("preview_url")
     val previewUrl: String?,

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/spotiffy/SpotifyController.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/spotiffy/SpotifyController.kt
@@ -1,0 +1,29 @@
+package com.umpa.core.controller.v1.spotiffy
+
+import com.umpa.core.controller.v1.spotiffy.response.SearchResponse
+import com.umpa.core.domain.song.spotify.SpotifyService
+import com.umpa.response.CommonApiResponse
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/spotify/songs")
+class SpotifyController(
+    private val spotifyService: SpotifyService
+) {
+    @GetMapping(
+        value = ["/search"],
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun search(
+        @RequestParam keyword: String,
+        @RequestParam cursor: String?
+    ): CommonApiResponse<SearchResponse> {
+        val result = spotifyService.search(keyword, cursor)
+        return CommonApiResponse.success(SearchResponse.fromSearchResult(result))
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/spotiffy/response/SearchResponse.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/spotiffy/response/SearchResponse.kt
@@ -1,0 +1,19 @@
+package com.umpa.core.controller.v1.spotiffy.response
+
+import com.umpa.core.domain.cursor.CursorKey
+import com.umpa.core.domain.song.spotify.SearchResult
+import com.umpa.core.domain.song.spotify.Track
+
+data class SearchResponse(
+    val cursor: String?,
+    val tracks: List<Track>
+) {
+    companion object {
+        fun fromSearchResult(result: SearchResult): SearchResponse {
+            return SearchResponse(
+                cursor = result.next?.let { CursorKey.extractFromUrl(it) }?.encode(),
+                tracks = result.tracks
+            )
+        }
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/cursor/CursorKey.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/cursor/CursorKey.kt
@@ -1,0 +1,36 @@
+package com.umpa.core.domain.cursor
+
+import java.util.Base64
+
+data class CursorKey(
+    val limit: Int?,
+    val offset: Int?
+) {
+    fun encode(): String? = Base64.getEncoder().encodeToString("$limit:$offset".toByteArray())
+
+    companion object {
+        fun fromBase64(key: String): CursorKey {
+            val decodedKey = String(Base64.getDecoder().decode(key))
+                .split(":")
+            return CursorKey(
+                limit = decodedKey[0].toIntOrNull(),
+                offset = decodedKey[1].toIntOrNull()
+            )
+        }
+
+        fun extractFromUrl(url: String): CursorKey {
+            val separatorIndex = url.indexOf("?")
+            var limit: Int? = null
+            var offset: Int? = null
+            url.substring(separatorIndex + 1).split("&")
+                .forEach {
+                    val (key, value) = it.split("=")
+                    when (key) {
+                        "limit" -> limit = value.toIntOrNull()
+                        "offset" -> offset = value.toIntOrNull()
+                    }
+                }
+            return CursorKey(limit = limit, offset = offset)
+        }
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/song/spotify/AlbumImage.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/song/spotify/AlbumImage.kt
@@ -1,0 +1,19 @@
+package com.umpa.core.domain.song.spotify
+
+import com.umpa.client.spotify.response.ImageResponse
+
+data class AlbumImage(
+    val url: String,
+    val height: Int,
+    val width: Int
+) {
+    companion object {
+        fun fromImageResponse(response: ImageResponse): AlbumImage {
+            return AlbumImage(
+                url = response.url,
+                height = response.height ?: 640,
+                width = response.width ?: 640
+            )
+        }
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/song/spotify/SearchResult.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/song/spotify/SearchResult.kt
@@ -1,0 +1,17 @@
+package com.umpa.core.domain.song.spotify
+
+import com.umpa.client.spotify.response.TrackResponse
+
+data class SearchResult(
+    val next: String?,
+    val tracks: List<Track>
+) {
+    companion object {
+        fun fromTrackResponse(response: TrackResponse): SearchResult {
+            return SearchResult(
+                next = response.next,
+                tracks = response.items.map { Track.fromTrackDetailResponse(it) }
+            )
+        }
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/song/spotify/SpotifyService.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/song/spotify/SpotifyService.kt
@@ -1,0 +1,22 @@
+package com.umpa.core.domain.song.spotify
+
+import com.umpa.client.spotify.SpotifyClient
+import com.umpa.core.domain.cursor.CursorKey
+import org.springframework.stereotype.Service
+
+@Service
+class SpotifyService(
+    private val spotifyClient: SpotifyClient
+) {
+    fun search(keyword: String, cursor: String?): SearchResult {
+        val cursorKey = cursor?.let {
+            CursorKey.fromBase64(it)
+        }
+        val searchResults = spotifyClient.search(
+            keyword = keyword,
+            limit = cursorKey?.limit,
+            offset = cursorKey?.offset
+        )
+        return SearchResult.fromTrackResponse(searchResults)
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/song/spotify/Track.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/song/spotify/Track.kt
@@ -1,0 +1,25 @@
+package com.umpa.core.domain.song.spotify
+
+import com.umpa.client.spotify.response.TrackDetailResponse
+
+data class Track(
+    val id: String,
+    val name: String,
+    val artistNames: List<String>,
+    val albumImage: AlbumImage,
+    val isExplicit: Boolean,
+    val previewUrl: String?
+) {
+    companion object {
+        fun fromTrackDetailResponse(response: TrackDetailResponse): Track {
+            return Track(
+                id = response.id,
+                name = response.name,
+                artistNames = response.artists.map { it.name },
+                albumImage = AlbumImage.fromImageResponse(response.album.images[0]),
+                isExplicit = response.explicit,
+                previewUrl = response.previewUrl
+            )
+        }
+    }
+}

--- a/umpa-core-api/src/test/kotlin/com/umpa/core/domain/cursor/CursorKeyTest.kt
+++ b/umpa-core-api/src/test/kotlin/com/umpa/core/domain/cursor/CursorKeyTest.kt
@@ -1,0 +1,39 @@
+package com.umpa.core.domain.cursor
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+internal class CursorKeyTest {
+    @ParameterizedTest
+    @CsvSource(
+        "MjA6MA==,20,0",
+        "bnVsbDow,,0",
+        "MjA6bnVsbA==,20,",
+        "bnVsbDpudWxs,,"
+    )
+    fun `각 limit, offset에 맞는 CursorKey를 반환한다`(key: String, limit: Int?, offset: Int?) {
+        val cursorKey = CursorKey.fromBase64(key)
+        assertThat(cursorKey.limit).isEqualTo(limit)
+        assertThat(cursorKey.offset).isEqualTo(offset)
+    }
+
+    @Test
+    fun `cursorKey를 조회한다`() {
+        val limit = null
+        val offset = null
+        val cursorKey = CursorKey(limit, offset)
+        println(cursorKey.encode())
+    }
+
+    @Test
+    fun `url에서 limit, offset을 찾아 cursorKey를 만든다`() {
+        val url = """
+            https://api.spotify.com/v1/search?query=ap+alchemy&type=track&locale=ko-KR%2Cko%3Bq%3D0.9%2Cen-US%3Bq%3D0.8%2Cen%3Bq%3D0.7&offset=3&limit=3
+        """.trimIndent()
+        val sut = CursorKey.extractFromUrl(url)
+        assertThat(sut.limit).isEqualTo(3)
+        assertThat(sut.offset).isEqualTo(3)
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
spotify client를 이용해서 곡을 검색할 수 있는 API를 제작했습니다.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [ ] Documentation update
- [ ] Other (please describe)
