### PR TITLE
댓글 도메인 및 관련 API 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ likes
 
 - [ ] 플레이리스트 상세 조회 ```GET /playlist/{id}/{postUserId}```
 
-- [ ] 댓글 작성 ```POST /playlist/comment/{id}```
+- [x] 댓글 작성 ```POST /playlist/comment/{id}```
 
-- [ ] 댓글 삭제 ```DELETE /playlist/comment/{id}/{commentId}```
+- [x] 댓글 삭제 ```DELETE /playlist/comment/{id}/{commentId}```
 
 - [ ] 대댓글 작성 ```POST /playlist/recomment/{id}/{commentId}```
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ User
 RDS로 마이그레이션 하기 위한 도메인은 다음과 같습니다.
 
 ```
-user
-playlist
-likes
+- user
+- content
+  - playlist
+- comments
+  - comment
+  - re-comment
+- likes
 ... TBD
 ```
 

--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ likes
 
 - [ ] 플레이리스트 상세 조회 ```GET /playlist/{id}/{postUserId}```
 
-- [x] 댓글 작성 ```POST /playlist/comment/{id}```
+- [x] 댓글 작성 ```POST /playlists/{id}/comments```
 
-- [x] 댓글 삭제 ```DELETE /playlist/comment/{id}/{commentId}```
+- [x] 댓글 삭제 ```DELETE /playlists/{id}/comments/{commentId}```
 
-- [ ] 대댓글 작성 ```POST /playlist/recomment/{id}/{commentId}```
+- [x] 대댓글 작성 ```POST /playlists/{id}/comments/{commentId}/re-comments```
 
-- [ ] 대댓글 삭제 ```DELETE /playlist/recomment/{id}/{commentId}```
+- [x] 대댓글 삭제 ```DELETE /playlists/{id}/comments/{commentId}/re-comments/{recommentId}```
 
 - [x] 플레이리스트 좋아요 ```POST /v1/playlists/{id}/likes```
 

--- a/storage/db-core/src/main/kotlin/com/umpa/storage/db/core/comment/CommentEntity.kt
+++ b/storage/db-core/src/main/kotlin/com/umpa/storage/db/core/comment/CommentEntity.kt
@@ -1,0 +1,28 @@
+package com.umpa.storage.db.core.comment
+
+import com.umpa.commons.enums.ContentType
+import com.umpa.storage.db.core.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(name = "comment")
+class CommentEntity(
+    @Column(name = "ref_content_id")
+    val contentId: Long,
+
+    @Column(name = "ref_user_id")
+    val userId: Long,
+
+    @Column(name = "comment")
+    val comment: String,
+
+    @Column(name = "ref_parent_comment_id")
+    val parentCommentId: Long? = null,
+
+    @Column(name = "content_type")
+    @Enumerated(value = EnumType.STRING)
+    val contentType: ContentType,
+
+    @Column(name = "is_deleted")
+    var isDeleted: Boolean = false
+) : BaseEntity()

--- a/storage/db-core/src/main/kotlin/com/umpa/storage/db/core/comment/CommentRepository.kt
+++ b/storage/db-core/src/main/kotlin/com/umpa/storage/db/core/comment/CommentRepository.kt
@@ -1,0 +1,7 @@
+package com.umpa.storage.db.core.comment
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentRepository : JpaRepository<CommentEntity, Long> {
+    fun readByContentId(contentId: Long): CommentEntity?
+}

--- a/storage/db-core/src/main/kotlin/com/umpa/storage/db/core/comment/CommentRepository.kt
+++ b/storage/db-core/src/main/kotlin/com/umpa/storage/db/core/comment/CommentRepository.kt
@@ -3,5 +3,5 @@ package com.umpa.storage.db.core.comment
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface CommentRepository : JpaRepository<CommentEntity, Long> {
-    fun readByContentId(contentId: Long): CommentEntity?
+    fun readById(id: Long): CommentEntity?
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/CommentController.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/CommentController.kt
@@ -43,4 +43,17 @@ class CommentController(
         commentService.create(body.toDomain(userId = 0L, contentId = id, parentCommentId = commentId))
         return CommonApiResponse.success()
     }
+
+    @DeleteMapping("/{id}/comments/{commentId}/re-comments/{reCommentId}")
+    fun removeReComment(
+        @PathVariable id: Long,
+        @PathVariable commentId: Long,
+        @PathVariable reCommentId: Long
+    ): CommonApiResponse<Nothing> {
+        // TODO 헤더로 넘어온 access-token에서 userId resolve해서 넘겨주어야 함
+        commentService.remove(
+            CommentRemoval(contentId = id, commentId = reCommentId, parentCommentId = commentId, userId = 0L)
+        )
+        return CommonApiResponse.success()
+    }
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/CommentController.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/CommentController.kt
@@ -32,4 +32,15 @@ class CommentController(
         commentService.remove(CommentRemoval(contentId = id, commentId = commentId, userId = 0L))
         return CommonApiResponse.success()
     }
+
+    @PostMapping("/{id}/comments/{commentId}/re-comments")
+    fun createReComment(
+        @PathVariable id: Long,
+        @PathVariable commentId: Long,
+        @RequestBody body: CreateCommentRequest
+    ): CommonApiResponse<Nothing> {
+        // TODO 헤더로 넘어온 access-token에서 userId resolve해서 넘겨주어야 함
+        commentService.create(body.toDomain(userId = 0L, contentId = id, parentCommentId = commentId))
+        return CommonApiResponse.success()
+    }
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/CommentController.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/CommentController.kt
@@ -2,6 +2,7 @@ package com.umpa.core.controller.v1.comment
 
 import com.umpa.commons.api.response.CommonApiResponse
 import com.umpa.core.controller.v1.comment.request.CreateCommentRequest
+import com.umpa.core.domain.comment.CommentRemoval
 import com.umpa.core.domain.comment.CommentService
 import org.springframework.web.bind.annotation.*
 
@@ -19,6 +20,16 @@ class CommentController(
     ): CommonApiResponse<Nothing> {
         // TODO 헤더로 넘어온 access-token에서 userId resolve해서 넘겨주어야 함
         commentService.create(body.toDomain(userId = 0L, contentId = id))
+        return CommonApiResponse.success()
+    }
+
+    @DeleteMapping("/{id}/comments/{commentId}")
+    fun removeComment(
+        @PathVariable id: Long,
+        @PathVariable commentId: Long
+    ): CommonApiResponse<Nothing> {
+        // TODO 헤더로 넘어온 access-token에서 userId resolve해서 넘겨주어야 함
+        commentService.remove(CommentRemoval(contentId = id, commentId = commentId, userId = 0L))
         return CommonApiResponse.success()
     }
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/CommentController.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/CommentController.kt
@@ -1,0 +1,24 @@
+package com.umpa.core.controller.v1.comment
+
+import com.umpa.commons.api.response.CommonApiResponse
+import com.umpa.core.controller.v1.comment.request.CreateCommentRequest
+import com.umpa.core.domain.comment.CommentService
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping(
+    "/v1/playlists"
+)
+class CommentController(
+    private val commentService: CommentService
+) {
+    @PostMapping("/{id}/comments")
+    fun createComment(
+        @PathVariable id: Long,
+        @RequestBody body: CreateCommentRequest
+    ): CommonApiResponse<Nothing> {
+        // TODO 헤더로 넘어온 access-token에서 userId resolve해서 넘겨주어야 함
+        commentService.create(body.toDomain(userId = 0L, contentId = id))
+        return CommonApiResponse.success()
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/request/CreateCommentRequest.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/controller/v1/comment/request/CreateCommentRequest.kt
@@ -1,0 +1,19 @@
+package com.umpa.core.controller.v1.comment.request
+
+import com.umpa.commons.enums.ContentType
+import com.umpa.core.domain.comment.CommentCreation
+
+data class CreateCommentRequest(
+    val comment: String,
+    val contentType: ContentType
+) {
+    fun toDomain(userId: Long, contentId: Long, parentCommentId: Long? = null): CommentCreation {
+        return CommentCreation(
+            contentId = contentId,
+            userId = userId,
+            comment = comment,
+            parentCommentId = parentCommentId,
+            contentType = contentType
+        )
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/Comment.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/Comment.kt
@@ -1,0 +1,33 @@
+package com.umpa.core.domain.comment
+
+import com.umpa.commons.enums.ContentType
+import com.umpa.storage.db.core.comment.CommentEntity
+import java.time.LocalDateTime
+
+data class Comment(
+    val id: Long,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val contentId: Long,
+    val userId: Long,
+    val comment: String,
+    val parentCommentId: Long?,
+    val contentType: ContentType,
+    val isDeleted: Boolean
+) {
+    companion object {
+        fun fromEntity(entity: CommentEntity): Comment {
+            return Comment(
+                id = entity.id,
+                createdAt = entity.createdAt,
+                updatedAt = entity.updatedAt,
+                contentId = entity.contentId,
+                userId = entity.userId,
+                comment = entity.comment,
+                parentCommentId = entity.parentCommentId,
+                contentType = entity.contentType,
+                isDeleted = entity.isDeleted
+            )
+        }
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentCreation.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentCreation.kt
@@ -1,0 +1,22 @@
+package com.umpa.core.domain.comment
+
+import com.umpa.commons.enums.ContentType
+import com.umpa.storage.db.core.comment.CommentEntity
+
+data class CommentCreation(
+    val contentId: Long,
+    val userId: Long,
+    val comment: String,
+    val parentCommentId: Long?,
+    val contentType: ContentType
+) {
+    fun toEntity(): CommentEntity {
+        return CommentEntity(
+            contentId = contentId,
+            userId = userId,
+            comment = comment,
+            parentCommentId = parentCommentId,
+            contentType = contentType
+        )
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentCreator.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentCreator.kt
@@ -1,0 +1,13 @@
+package com.umpa.core.domain.comment
+
+import com.umpa.storage.db.core.comment.CommentRepository
+import org.springframework.stereotype.Component
+
+@Component
+class CommentCreator(
+    private val commentRepository: CommentRepository
+) {
+    fun create(creation: CommentCreation) {
+        commentRepository.save(creation.toEntity())
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentReader.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentReader.kt
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Component
 class CommentReader(
     private val commentRepository: CommentRepository
 ) {
-    fun readByContentId(contentId: Long): Comment {
-        return commentRepository.readByContentId(contentId)?.let {
+    fun readById(id: Long): Comment {
+        return commentRepository.readById(id)?.let {
             Comment.fromEntity(it)
         } ?: throw CoreApiException(ErrorType.NOT_FOUND_COMMENT)
     }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentReader.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentReader.kt
@@ -1,0 +1,17 @@
+package com.umpa.core.domain.comment
+
+import com.umpa.core.support.exceptions.CoreApiException
+import com.umpa.core.support.exceptions.ErrorType
+import com.umpa.storage.db.core.comment.CommentRepository
+import org.springframework.stereotype.Component
+
+@Component
+class CommentReader(
+    private val commentRepository: CommentRepository
+) {
+    fun readByContentId(contentId: Long): Comment {
+        return commentRepository.readByContentId(contentId)?.let {
+            Comment.fromEntity(it)
+        } ?: throw CoreApiException(ErrorType.NOT_FOUND_COMMENT)
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentReader.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentReader.kt
@@ -2,6 +2,7 @@ package com.umpa.core.domain.comment
 
 import com.umpa.core.support.exceptions.CoreApiException
 import com.umpa.core.support.exceptions.ErrorType
+import com.umpa.storage.db.core.comment.CommentEntity
 import com.umpa.storage.db.core.comment.CommentRepository
 import org.springframework.stereotype.Component
 
@@ -9,9 +10,8 @@ import org.springframework.stereotype.Component
 class CommentReader(
     private val commentRepository: CommentRepository
 ) {
-    fun readById(id: Long): Comment {
-        return commentRepository.readById(id)?.let {
-            Comment.fromEntity(it)
-        } ?: throw CoreApiException(ErrorType.NOT_FOUND_COMMENT)
+    fun readById(id: Long): CommentEntity {
+        return commentRepository.readById(id)
+            ?: throw CoreApiException(ErrorType.NOT_FOUND_COMMENT)
     }
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentRemoval.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentRemoval.kt
@@ -1,0 +1,19 @@
+package com.umpa.core.domain.comment
+
+import com.umpa.core.support.exceptions.CoreApiException
+import com.umpa.core.support.exceptions.ErrorType
+
+data class CommentRemoval(
+    val contentId: Long,
+    val commentId: Long,
+    val userId: Long
+) {
+    fun validate(comment: Comment) {
+        if (contentId != comment.contentId) {
+            throw CoreApiException(ErrorType.FORBIDDEN_CONTENT_ID)
+        }
+        if (userId != comment.userId) {
+            throw CoreApiException(ErrorType.FORBIDDEN_USER_ID)
+        }
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentRemoval.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentRemoval.kt
@@ -6,6 +6,7 @@ import com.umpa.core.support.exceptions.ErrorType
 data class CommentRemoval(
     val contentId: Long,
     val commentId: Long,
+    val parentCommentId: Long? = null,
     val userId: Long
 ) {
     fun validate(comment: Comment) {
@@ -14,6 +15,10 @@ data class CommentRemoval(
         }
         if (userId != comment.userId) {
             throw CoreApiException(ErrorType.FORBIDDEN_USER_ID)
+        }
+
+        if (parentCommentId != null && parentCommentId != comment.parentCommentId) {
+            throw CoreApiException(ErrorType.FORBIDDEN_PARENT_COMMENT_ID)
         }
     }
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
@@ -14,7 +14,7 @@ class CommentService(
     }
 
     fun remove(removal: CommentRemoval) {
-        val comment = commentReader.readById(removal.contentId)
+        val comment = commentReader.readById(removal.contentId).let { Comment.fromEntity(it) }
         removal.validate(comment)
         commentUpdater.deleteByContentId(removal.commentId)
         // TODO notice도 delete

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
@@ -13,9 +13,9 @@ class CommentService(
     }
 
     fun remove(removal: CommentRemoval) {
-        val comment = commentReader.readByContentId(removal.contentId)
+        val comment = commentReader.readById(removal.contentId)
         removal.validate(comment)
-        commentWriter.deleteByContentId(removal.contentId)
+        commentWriter.deleteByContentId(removal.commentId)
         // TODO notice도 delete
     }
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
@@ -1,0 +1,13 @@
+package com.umpa.core.domain.comment
+
+import org.springframework.stereotype.Service
+
+@Service
+class CommentService(
+    private val commentWriter: CommentWriter
+) {
+    fun create(creation: CommentCreation) {
+        commentWriter.write(creation)
+        // TODO notice 추가 + push notification
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
@@ -4,10 +4,18 @@ import org.springframework.stereotype.Service
 
 @Service
 class CommentService(
-    private val commentWriter: CommentWriter
+    private val commentWriter: CommentWriter,
+    private val commentReader: CommentReader
 ) {
     fun create(creation: CommentCreation) {
         commentWriter.write(creation)
         // TODO notice 추가 + push notification
+    }
+
+    fun remove(removal: CommentRemoval) {
+        val comment = commentReader.readByContentId(removal.contentId)
+        removal.validate(comment)
+        commentWriter.deleteByContentId(removal.contentId)
+        // TODO notice도 delete
     }
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentService.kt
@@ -4,18 +4,19 @@ import org.springframework.stereotype.Service
 
 @Service
 class CommentService(
-    private val commentWriter: CommentWriter,
-    private val commentReader: CommentReader
+    private val commentCreator: CommentCreator,
+    private val commentReader: CommentReader,
+    private val commentUpdater: CommentUpdater
 ) {
     fun create(creation: CommentCreation) {
-        commentWriter.write(creation)
+        commentCreator.create(creation)
         // TODO notice 추가 + push notification
     }
 
     fun remove(removal: CommentRemoval) {
         val comment = commentReader.readById(removal.contentId)
         removal.validate(comment)
-        commentWriter.deleteByContentId(removal.commentId)
+        commentUpdater.deleteByContentId(removal.commentId)
         // TODO notice도 delete
     }
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentUpdater.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentUpdater.kt
@@ -7,13 +7,9 @@ import jakarta.transaction.Transactional
 import org.springframework.stereotype.Component
 
 @Component
-class CommentWriter(
+class CommentUpdater (
     private val commentRepository: CommentRepository
-) {
-    fun write(creation: CommentCreation) {
-        commentRepository.save(creation.toEntity())
-    }
-
+){
     @Transactional
     fun deleteByContentId(id: Long) {
         commentRepository.readById(id)?.apply {

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentUpdater.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentUpdater.kt
@@ -7,9 +7,9 @@ import jakarta.transaction.Transactional
 import org.springframework.stereotype.Component
 
 @Component
-class CommentUpdater (
+class CommentUpdater(
     private val commentRepository: CommentRepository
-){
+) {
     @Transactional
     fun deleteByContentId(id: Long) {
         commentRepository.readById(id)?.apply {

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentWriter.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentWriter.kt
@@ -1,0 +1,23 @@
+package com.umpa.core.domain.comment
+
+import com.umpa.core.support.exceptions.CoreApiException
+import com.umpa.core.support.exceptions.ErrorType
+import com.umpa.storage.db.core.comment.CommentRepository
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Component
+
+@Component
+class CommentWriter(
+    private val commentRepository: CommentRepository
+) {
+    fun write(creation: CommentCreation) {
+        commentRepository.save(creation.toEntity())
+    }
+
+    @Transactional
+    fun deleteByContentId(contentId: Long) {
+        commentRepository.readByContentId(contentId)?.apply {
+            this.isDeleted = true
+        } ?: throw CoreApiException(ErrorType.NOT_FOUND_COMMENT)
+    }
+}

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentWriter.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/domain/comment/CommentWriter.kt
@@ -15,8 +15,8 @@ class CommentWriter(
     }
 
     @Transactional
-    fun deleteByContentId(contentId: Long) {
-        commentRepository.readByContentId(contentId)?.apply {
+    fun deleteByContentId(id: Long) {
+        commentRepository.readById(id)?.apply {
             this.isDeleted = true
         } ?: throw CoreApiException(ErrorType.NOT_FOUND_COMMENT)
     }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/support/exceptions/ErrorCode.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/support/exceptions/ErrorCode.kt
@@ -7,7 +7,10 @@ enum class ErrorCode {
 
     E4030,
     E4031,
+    E4032,
+    E4033,
 
     E4040,
-    E4041
+    E4041,
+    E4042
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/support/exceptions/ErrorCode.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/support/exceptions/ErrorCode.kt
@@ -9,6 +9,7 @@ enum class ErrorCode {
     E4031,
     E4032,
     E4033,
+    E4034,
 
     E4040,
     E4041,

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/support/exceptions/ErrorType.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/support/exceptions/ErrorType.kt
@@ -8,8 +8,11 @@ enum class ErrorType(val statusCode: HttpStatus, val errorCode: ErrorCode, val m
     NOT_SUPPORTED_SPC_PATTERN(HttpStatus.BAD_REQUEST, ErrorCode.E4002, "특수문자를 포함할 수 없습니다. 한글, 영문, 숫자로 입력해주세요"),
 
     BAD_CREDENTIALS(HttpStatus.FORBIDDEN, ErrorCode.E4030, "입력하신 비밀번호와 일치하지 않습니다."),
-    FORBIDDEN_UNLIKE(HttpStatus.FORBIDDEN, ErrorCode.E4031, "좋아요를 취소할 수 없습니다."),
+    FORBIDDEN_CONTENT_ID(HttpStatus.FORBIDDEN, ErrorCode.E4031, "해당 컨텐츠와 일치하지 않습니다."),
+    FORBIDDEN_USER_ID(HttpStatus.FORBIDDEN, ErrorCode.E4032, "해당 유저와 일치하지 않습니다."),
+    FORBIDDEN_UNLIKE(HttpStatus.FORBIDDEN, ErrorCode.E4033, "좋아요를 취소할 수 없습니다."),
 
     NOT_FOUND_USER_EMAIL(HttpStatus.NOT_FOUND, ErrorCode.E4040, "해당 이메일과 일치하는 유저를 찾을 수 없습니다."),
-    NOT_FOUND_LIKES(HttpStatus.NOT_FOUND, ErrorCode.E4041, "해당 좋아요를 찾을 수 없습니다.")
+    NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, ErrorCode.E4041, "해당 댓글을 찾을 수 없습니다."),
+    NOT_FOUND_LIKES(HttpStatus.NOT_FOUND, ErrorCode.E4042, "해당 좋아요를 찾을 수 없습니다.")
 }

--- a/umpa-core-api/src/main/kotlin/com/umpa/core/support/exceptions/ErrorType.kt
+++ b/umpa-core-api/src/main/kotlin/com/umpa/core/support/exceptions/ErrorType.kt
@@ -10,7 +10,8 @@ enum class ErrorType(val statusCode: HttpStatus, val errorCode: ErrorCode, val m
     BAD_CREDENTIALS(HttpStatus.FORBIDDEN, ErrorCode.E4030, "입력하신 비밀번호와 일치하지 않습니다."),
     FORBIDDEN_CONTENT_ID(HttpStatus.FORBIDDEN, ErrorCode.E4031, "해당 컨텐츠와 일치하지 않습니다."),
     FORBIDDEN_USER_ID(HttpStatus.FORBIDDEN, ErrorCode.E4032, "해당 유저와 일치하지 않습니다."),
-    FORBIDDEN_UNLIKE(HttpStatus.FORBIDDEN, ErrorCode.E4033, "좋아요를 취소할 수 없습니다."),
+    FORBIDDEN_PARENT_COMMENT_ID(HttpStatus.FORBIDDEN, ErrorCode.E4033, "댓글이 일치하지 않습니다."),
+    FORBIDDEN_UNLIKE(HttpStatus.FORBIDDEN, ErrorCode.E4034, "좋아요를 취소할 수 없습니다."),
 
     NOT_FOUND_USER_EMAIL(HttpStatus.NOT_FOUND, ErrorCode.E4040, "해당 이메일과 일치하는 유저를 찾을 수 없습니다."),
     NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, ErrorCode.E4041, "해당 댓글을 찾을 수 없습니다."),

--- a/umpa-core-api/src/test/kotlin/com/umpa/core/domain/comment/CommentServiceTest.kt
+++ b/umpa-core-api/src/test/kotlin/com/umpa/core/domain/comment/CommentServiceTest.kt
@@ -1,0 +1,42 @@
+package com.umpa.core.domain.comment
+
+import com.umpa.core.fixtures.domains.comment.CommentRemovalBuilder
+import com.umpa.core.fixtures.entity.comment.CommentEntityBuilder
+import com.umpa.core.support.exceptions.CoreApiException
+import com.umpa.core.support.exceptions.ErrorType
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+internal class CommentServiceTest {
+    private val commentCreator = mockk<CommentCreator>()
+    private val commentReader = mockk<CommentReader>()
+    private val commentUpdater = mockk<CommentUpdater>()
+    private val sut = CommentService(commentCreator, commentReader, commentUpdater)
+
+    @ParameterizedTest
+    @CsvSource(
+        "1,0,,FORBIDDEN_CONTENT_ID",
+        "0,1,,FORBIDDEN_USER_ID",
+        "0,0,0,FORBIDDEN_PARENT_COMMENT_ID"
+    )
+    fun `comment 제거할 때, removal 검증에 실패하면 에러가 발생한다`(contentId: Long, userId: Long, parentCommentId: Long?, errorType: ErrorType) {
+        val removal = CommentRemovalBuilder(
+            parentCommentId = parentCommentId
+        ).build()
+        val commentEntity = CommentEntityBuilder(
+            contentId = contentId,
+            userId = userId,
+            parentCommentId = parentCommentId?.inc()
+        ).build()
+
+        every { commentReader.readById(any()) } returns commentEntity
+
+        val exception = assertThrows<CoreApiException> { sut.remove(removal) }
+
+        exception.errorType shouldBe errorType
+    }
+}

--- a/umpa-core-api/src/test/kotlin/com/umpa/core/fixtures/domains/comment/CommentRemovalBuilder.kt
+++ b/umpa-core-api/src/test/kotlin/com/umpa/core/fixtures/domains/comment/CommentRemovalBuilder.kt
@@ -1,0 +1,19 @@
+package com.umpa.core.fixtures.domains.comment
+
+import com.umpa.core.domain.comment.CommentRemoval
+
+class CommentRemovalBuilder(
+    val contentId: Long = 0L,
+    val commentId: Long = 0L,
+    val parentCommentId: Long? = null,
+    val userId: Long = 0L
+) {
+    fun build(): CommentRemoval {
+        return CommentRemoval(
+            contentId = contentId,
+            commentId = commentId,
+            parentCommentId = parentCommentId,
+            userId = userId,
+        )
+    }
+}

--- a/umpa-core-api/src/test/kotlin/com/umpa/core/fixtures/entity/comment/CommentEntityBuilder.kt
+++ b/umpa-core-api/src/test/kotlin/com/umpa/core/fixtures/entity/comment/CommentEntityBuilder.kt
@@ -1,0 +1,24 @@
+package com.umpa.core.fixtures.entity.comment
+
+import com.umpa.commons.enums.ContentType
+import com.umpa.storage.db.core.comment.CommentEntity
+
+class CommentEntityBuilder(
+    val contentId: Long = 0L,
+    val userId: Long = 0L,
+    val comment: String = "comment",
+    val parentCommentId: Long? = null,
+    val contentType: ContentType = ContentType.PLAYLIST,
+    var isDeleted: Boolean = false
+) {
+    fun build(): CommentEntity {
+        return CommentEntity(
+            contentId = contentId,
+            userId = userId,
+            comment = comment,
+            parentCommentId = parentCommentId,
+            contentType = contentType,
+            isDeleted = isDeleted,
+        )
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
댓글 도메인을 생성하고 관련 API(댓글 + 대댓글 생성, 삭제)를 추가했습니다.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Enhancement
- [x] Documentation update
- [ ] Other (please describe)

## Additional Notes
추후에 데일리, 릴레이 플리 댓글 대댓글도 해당 `CommentController`를 통해 라우팅 될 수 있도록 해야 합니다.